### PR TITLE
fix: address review issues from 2026-06-09

### DIFF
--- a/src/fetch-download/DownloadTask.ts
+++ b/src/fetch-download/DownloadTask.ts
@@ -332,6 +332,7 @@ export class DownloadTask {
     if (this.#chunks != null) return this;
 
     const chunkAry: Uint8Array[] = [];
+    let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
 
     try {
       if (this.isStarted) {
@@ -358,7 +359,7 @@ export class DownloadTask {
         throw this.newErr('Invalid response');
       }
 
-      const reader = this.#resp.body.getReader();
+      reader = this.#resp.body.getReader();
       if (reader == null) {
         throw this.newErr('Create stream reader error');
       }
@@ -410,13 +411,14 @@ export class DownloadTask {
           this.#size = this.#received;
         }
 
-        // 当 content-length === 0 时候，progress 一直都是 1
-        this.#progress = calcProgress(this.#received, this.#size);
+        this.#progress = this.#size === 0 ? 1 : calcProgress(this.#received, this.#size);
         await opts?.onProgress?.(this);
       }
     } catch (err) {
       this.#state = DownloadTaskState.error;
       this.#error = err;
+      await reader?.cancel().catch(() => {});
+      reader = undefined;
     }
 
     if (this.#received > 0) {

--- a/src/traits/core.test.ts
+++ b/src/traits/core.test.ts
@@ -139,6 +139,80 @@ describe('traits/core', () => {
       expect(() => implTraits(arrow as never, { x() {} })).not.toThrow();
     });
   });
+
+  describe('Symbol key support', () => {
+    it('[Symbol.iterator] is copied to prototype', () => {
+      // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: implTraits guarantees runtime implementation
+      class NumberList {
+        items: number[];
+        constructor(...items: number[]) {
+          this.items = items;
+        }
+      }
+
+      implTraits(NumberList, {
+        [Symbol.iterator](this: NumberList) {
+          return this.items[Symbol.iterator]();
+        },
+      });
+
+      const list = new NumberList(1, 2, 3);
+      expect([...(list as unknown as Iterable<number>)]).toEqual([1, 2, 3]);
+    });
+
+    it('[Symbol.toPrimitive] is copied to prototype', () => {
+      // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: implTraits guarantees runtime implementation
+      class Box {
+        value: number;
+        constructor(v: number) {
+          this.value = v;
+        }
+      }
+
+      implTraits(Box, {
+        [Symbol.toPrimitive](this: Box, hint: string) {
+          return hint === 'string' ? `Box(${this.value})` : this.value;
+        },
+      });
+
+      const box = new Box(42);
+      expect(+box).toBe(42);
+      expect(`${box}`).toBe('Box(42)');
+    });
+
+    it('user-defined Symbol method is copied', () => {
+      const kTag = Symbol('tag');
+
+      // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: implTraits guarantees runtime implementation
+      class Tagged {}
+
+      implTraits(Tagged, {
+        [kTag](this: Tagged) {
+          return 'tagged';
+        },
+      });
+
+      const t = new Tagged();
+      // biome-ignore lint/suspicious/noExplicitAny: symbol indexing requires any cast
+      expect((t as any)[kTag]()).toBe('tagged');
+    });
+
+    it('Symbol methods live on the prototype, not the instance', () => {
+      // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: implTraits guarantees runtime implementation
+      class Thing {}
+
+      implTraits(Thing, {
+        [Symbol.iterator](this: Thing) {
+          return [][Symbol.iterator]();
+        },
+      });
+
+      const t = new Thing();
+      expect(Object.hasOwn(t, Symbol.iterator)).toBe(false);
+      // biome-ignore lint/suspicious/noExplicitAny: symbol indexing requires any cast
+      expect(typeof (Thing.prototype as any)[Symbol.iterator]).toBe('function');
+    });
+  });
 });
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/src/traits/core.test.ts
+++ b/src/traits/core.test.ts
@@ -142,7 +142,6 @@ describe('traits/core', () => {
 
   describe('Symbol key support', () => {
     it('[Symbol.iterator] is copied to prototype', () => {
-      // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: implTraits guarantees runtime implementation
       class NumberList {
         items: number[];
         constructor(...items: number[]) {
@@ -161,7 +160,6 @@ describe('traits/core', () => {
     });
 
     it('[Symbol.toPrimitive] is copied to prototype', () => {
-      // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: implTraits guarantees runtime implementation
       class Box {
         value: number;
         constructor(v: number) {
@@ -183,7 +181,6 @@ describe('traits/core', () => {
     it('user-defined Symbol method is copied', () => {
       const kTag = Symbol('tag');
 
-      // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: implTraits guarantees runtime implementation
       class Tagged {}
 
       implTraits(Tagged, {
@@ -198,7 +195,6 @@ describe('traits/core', () => {
     });
 
     it('Symbol methods live on the prototype, not the instance', () => {
-      // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: implTraits guarantees runtime implementation
       class Thing {}
 
       implTraits(Thing, {

--- a/src/traits/core.ts
+++ b/src/traits/core.ts
@@ -77,6 +77,7 @@ type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) exten
  * ### 注意事项
  * - 跳过 `constructor` 属性，避免破坏原型链
  * - 使用 `defineProperty` 而非赋值，能正确处理 getter / setter
+ * - 同时复制字符串键和 Symbol 键（`Object.getOwnPropertySymbols`），支持 `[Symbol.iterator]` 等 Well-Known Symbol
  * - 类型侧需配合 `interface MyClass extends TraitA, TraitB {}` 声明合并
  * - 使用 Biome 时需加两处 biome-ignore：class 声明前 suppress `noUnsafeDeclarationMerging`，
  *   interface 声明前 suppress `noUnusedVariables`：
@@ -99,7 +100,11 @@ export function implTraits<T extends object, Traits extends object[]>(
 ): void {
   if (!isCtor(ctor)) return;
   for (const trait of traits as object[]) {
-    for (const name of Object.getOwnPropertyNames(trait)) {
+    const keys: (string | symbol)[] = [
+      ...Object.getOwnPropertyNames(trait),
+      ...Object.getOwnPropertySymbols(trait),
+    ];
+    for (const name of keys) {
       if (name === 'constructor') continue;
       const descriptor = Object.getOwnPropertyDescriptor(trait, name);
       if (descriptor) {


### PR DESCRIPTION
- DownloadTask: guard mid-stream calcProgress(0,0) when #size is 0
- DownloadTask: move reader declaration outside try so catch can cancel it
- DownloadTask: call reader.cancel() in catch to release locked Response.body
- implTraits: copy Symbol-keyed properties via getOwnPropertySymbols
- implTraits: note Symbol support in JSDoc
- Add Symbol key tests: Symbol.iterator, Symbol.toPrimitive, user Symbol, prototype slot